### PR TITLE
Update pipe-tools to v0.1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN set -ex \
         /usr/share/doc-base
 
 # Setup pipeline debugging tools
-RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v0.1.5a
+RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v0.1.6
 
 # Setup airflow home directory
 WORKDIR ${AIRFLOW_HOME}


### PR DESCRIPTION
close #5 

Pipe-tools v0.1.6 provides exponential backoff as the default retry mode in airflow