### PR TITLE
Features/upgrade airflow 1.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,6 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### Added
   * [#884](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/884):
-    Migrates Airflow version to 1.10.1 on pipe-tools.
-    Ignore the `GPL License`
-    Uses `postgres` instead of `mysql`, because the property specified here (https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#mysql-setting-required) could not be changed in CloudSQL.
-    Update the pipe-tools version.
-    Include all the new properties in `airflow.cfg` that comes with the upgrade.
+    * Migrates Airflow version to 1.10.1 on pipe-tools.
+    * Uses `postgres` instead of `mysql`, because the property specified here (https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#mysql-setting-required) could not be changed in CloudSQL.
+    * Update the pipe-tools version to 1.0.0.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+  * [#884](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/884):
+    Migrates Airflow version to 1.10.1 on pipe-tools.
+    Ignore the `GPL License`
+    Uses `postgres` instead of `mysql`, because the property specified here (https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#mysql-setting-required) could not be changed in CloudSQL.
+    Update the pipe-tools version.
+    Include all the new properties in `airflow.cfg` that comes with the upgrade.

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,6 @@ RUN set -ex \
         libblas-dev \
         liblapack-dev \
         libpq-dev \
-        default-libmysqlclient-dev \
         git \
     ' \
     && apt-get update -yqq \
@@ -76,7 +75,8 @@ RUN set -ex \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install celery[redis] \
-    && pip install apache-airflow[mysql,crypto,celery,jdbc]==$AIRFLOW_VERSION \
+    && pip install apache-airflow[postgres,crypto,celery,jdbc]==$AIRFLOW_VERSION \
+    && pip install psycopg2 \
     && apt-get remove --purge -yqq $buildDeps libpq-dev \
     && apt-get clean \
     && rm -rf \
@@ -88,7 +88,7 @@ RUN set -ex \
         /usr/share/doc-base
 
 # Setup pipeline debugging tools
-RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/d884-1
+RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/d884-2
 
 # Setup airflow home directory
 WORKDIR ${AIRFLOW_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ ENV AIRFLOW_VERSION 1.10.1
 ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
+# Pipe-tools
+ENV PIPE_TOOLS_VERSION v1.0.0
+
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 
@@ -88,7 +91,7 @@ RUN set -ex \
         /usr/share/doc-base
 
 # Setup pipeline debugging tools
-RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v1.0.0
+RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/${PIPE_TOOLS_VERSION}
 
 # Setup airflow home directory
 WORKDIR ${AIRFLOW_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow configuration
-ENV AIRFLOW_VERSION 1.9.0
+ENV AIRFLOW_VERSION 1.10.0
 ENV AIRFLOW_HOME /usr/local/airflow
+ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
@@ -87,7 +88,7 @@ RUN set -ex \
         /usr/share/doc-base
 
 # Setup pipeline debugging tools
-RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v0.2.0
+RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/d884-1
 
 # Setup airflow home directory
 WORKDIR ${AIRFLOW_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN set -ex \
         /usr/share/doc-base
 
 # Setup pipeline debugging tools
-RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/d884-3
+RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v1.0.0
 
 # Setup airflow home directory
 WORKDIR ${AIRFLOW_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow configuration
-ENV AIRFLOW_VERSION 1.10.0
+ENV AIRFLOW_VERSION 1.10.1
 ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
@@ -88,7 +88,7 @@ RUN set -ex \
         /usr/share/doc-base
 
 # Setup pipeline debugging tools
-RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/d884-2
+RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/d884-3
 
 # Setup airflow home directory
 WORKDIR ${AIRFLOW_HOME}

--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -82,6 +82,10 @@ authenticate = False
 # Filter the list of dags by owner name (requires authentication to be enabled)
 filter_by_owner = False
 
+#Add a configuration variable(default_dag_run_display_number) to control numbers of dag run for display
+#https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#add-a-configuration-variabledefault_dag_run_display_number-to-control-numbers-of-dag-run-for-display
+default_dag_run_display_number=100
+
 [email]
 email_backend = airflow.utils.send_email_smtp
 
@@ -106,4 +110,83 @@ scheduler_heartbeat_sec = 5
 # This defines how many threads will run. However airflow will never
 # use more threads than the amount of cpu cores available.
 max_threads = 2
+
+# Airflow 1.10
+
+[ldap]
+# set a connection without encryption: uri = ldap://<your.ldap.server>:<port>
+uri=
+user_filter=
+# in case of Active Directory you would use: user_name_attr = sAMAccountName
+user_name_attr=
+# group_member_attr should be set accordingly with *_filter
+# eg :
+#     group_member_attr = groupMembership
+#     superuser_filter = groupMembership=CN=airflow-super-users...
+group_member_attr=
+superuser_filter=
+data_profiler_filter=
+bind_user=
+bind_password=
+basedn=
+cacert=
+# Set search_scope to one of them:  BASE, LEVEL , SUBTREE
+# Set search_scope to SUBTREE if using Active Directory, and not specifying an Organizational Unit
+search_scope=
+
+[lineage]
+# backend=airflow.lineage.backend.atlas
+backend=
+
+[atlas]
+username=
+password=
+host=
+port=
+
+[kubernetes]
+logs_volume_subpath=
+git_repo=
+git_user=
+worker_container_repository=
+image_pull_secrets=
+git_sync_container_tag=
+in_cluster=
+namespace=
+dags_volume_subpath=
+git_sync_init_container_name=
+dags_volume_claim=
+git_subpath=
+worker_service_account_name=
+git_branch=
+logs_volume_claim=
+gcp_service_account_keys=
+airflow_configmap=
+git_sync_container_repository=
+worker_container_tag=
+git_password=
+delete_worker_pods=
+default_hive_mapred_queue=
+cluster_address=
+tls_cert=
+tls_key=
+tls_ca=
+elasticsearch_host=
+elasticsearch_log_id_template=
+elasticsearch_end_of_log_mark=
+
+[hive]
+default_hive_mapred_queue=
+
+[dask]
+cluster_address=
+tls_cert=
+tls_key=
+tls_ca=
+
+[elasticsearch]
+elasticsearch_host=
+elasticsearch_log_id_template=
+elasticsearch_end_of_log_mark=
+
 

--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -14,7 +14,7 @@ base_log_folder = /usr/local/airflow/logs
 executor = LocalExecutor
 
 # The SqlAlchemy connection string is built from a command
-sql_alchemy_conn = mysql://${CLOUDSQL_USER}:${CLOUDSQL_PASSWORD}@${CLOUDSQL_SERVICE_HOST}:${CLOUDSQL_SERVICE_PORT}/${CLOUDSQL_DB}
+sql_alchemy_conn = postgres://${CLOUDSQL_USER}:${CLOUDSQL_PASSWORD}@${CLOUDSQL_SERVICE_HOST}:${CLOUDSQL_SERVICE_PORT}/${CLOUDSQL_DB}
 
 # The SqlAlchemy pool size is the maximum number of database connections
 # in the pool.
@@ -111,7 +111,10 @@ scheduler_heartbeat_sec = 5
 # use more threads than the amount of cpu cores available.
 max_threads = 2
 
-# Airflow 1.10
+#####################################
+# Properties added for Airflow 1.10
+# Please uncomment and adjust in each preference
+#####################################
 
 [ldap]
 # set a connection without encryption: uri = ldap://<your.ldap.server>:<port>
@@ -135,45 +138,46 @@ cacert=
 search_scope=
 
 [lineage]
-# backend=airflow.lineage.backend.atlas
 backend=
 
+see https://airflow.apache.org/lineage.html#apache-atlas
 [atlas]
 username=
 password=
 host=
 port=
 
+see https://github.com/apache/incubator-airflow/blob/1.10.0/scripts/ci/kubernetes/kube/configmaps.yaml
 [kubernetes]
-logs_volume_subpath=
-git_repo=
-git_user=
-worker_container_repository=
-image_pull_secrets=
-git_sync_container_tag=
-in_cluster=
-namespace=
-dags_volume_subpath=
-git_sync_init_container_name=
-dags_volume_claim=
-git_subpath=
-worker_service_account_name=
-git_branch=
-logs_volume_claim=
-gcp_service_account_keys=
 airflow_configmap=
-git_sync_container_repository=
-worker_container_tag=
-git_password=
-delete_worker_pods=
-default_hive_mapred_queue=
 cluster_address=
-tls_cert=
-tls_key=
-tls_ca=
+dags_volume_claim=
+dags_volume_subpath=
+default_hive_mapred_queue=
+delete_worker_pods=
+elasticsearch_end_of_log_mark=
 elasticsearch_host=
 elasticsearch_log_id_template=
-elasticsearch_end_of_log_mark=
+gcp_service_account_keys=
+git_branch=
+git_password=
+git_repo=
+git_subpath=
+git_sync_container_repository=
+git_sync_container_tag=
+git_sync_init_container_name=
+git_user=
+image_pull_secrets=
+in_cluster=
+logs_volume_claim=
+logs_volume_subpath=
+namespace=
+tls_ca=
+tls_cert=
+tls_key=
+worker_container_repository=
+worker_container_tag=
+worker_service_account_name=
 
 [hive]
 default_hive_mapred_queue=
@@ -185,8 +189,64 @@ tls_key=
 tls_ca=
 
 [elasticsearch]
+elasticsearch_end_of_log_mark=
 elasticsearch_host=
 elasticsearch_log_id_template=
-elasticsearch_end_of_log_mark=
 
+# [mesos]
+# authenticate=
+# checkpoint=
+# framework_name=
+# master=
+# task_cpu=
+# task_memory=
 
+# [smtp]
+# smtp_host=
+# smtp_mail_from=
+# smtp_port=
+# smtp_ssl=
+# smtp_starttls=
+
+# [api]
+# auth_backend=
+
+# [github_enterprise]
+# api_rev=
+
+# [cli]
+# api_client=
+# endpoint_url=
+
+# [celery]
+# ssl_key=
+# flower_port=
+# celery_app_name=
+# worker_concurrency=
+# default_queue=
+# ssl_cacert=
+# flower_url_prefix=
+# flower_host=
+# ssl_cert=
+# celery_config_options=
+# worker_log_server_port=
+# broker_url=
+# result_backend=
+# ssl_active=
+
+# [operators]
+# default_cpus=
+# default_disk=
+# default_gpus=
+# default_owner=
+# default_ram=
+
+# [kerberos]
+# ccache=
+# keytab=
+# kinit_path=
+# principal=
+# reinit_frequency=
+
+# [admin]
+# hide_sensitive_variable_fields=

--- a/scripts/initialize
+++ b/scripts/initialize
@@ -12,7 +12,6 @@ function ensure_pool {
   fi
 }
 
-
 echo "Initialize airflow database"
 airflow initdb
 

--- a/scripts/initialize
+++ b/scripts/initialize
@@ -12,6 +12,7 @@ function ensure_pool {
   fi
 }
 
+
 echo "Initialize airflow database"
 airflow initdb
 


### PR DESCRIPTION
* Upgrades Airflow to version 1.10.0
* Ignore the `GPL License`
* Uses postgres instead of mysql, because the property specified here (https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#mysql-setting-required) could not be changed in CloudSQL.
* Update the pipe-tools version.
* Include all the new properties in `airflow.cfg` that comes with the upgrade.

Related to https://github.com/GlobalFishingWatch/GFW-Tasks/issues/884