### PR TITLE
Features/1100 flexible operator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,40 +8,48 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
-###Added
-
-* {GFW-Tasks/issues/1100}(https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100): Adds
-  * Update of airflow from 1.10.1 to 1.10.2
-  * CLOUD_SDK_VERSION was updated from 198.0.0 to 248.0.0
-  * The `tzlocal` library has deployed a new version on 23rd of July, the
-   version `2.0.0` (https://pypi.org/project/tzlocal/2.0.0/#history). This lib
-   brokes the compilation. Apache Airflow requires the `tzlocal` and
-   `pendulum` libraries to be installed. In the `setup.py` file, the section
-   `install_requires`, appears the dependencies and the lib `tzlocal>=1.4` and
-   `pendulum==1.4.4`
-   (https://github.com/apache/airflow/blob/1.10.2/setup.py#L337). The
-   `pendulum` lib brokes with lib `tzlocal==2.0.0`, so right now I pinned to
-   the previous version, the `1.5.1`.
-  * Removing the `pipe-tools` dependency in pipe-airflow. This library will be used for projects that will run inside airflow.
-
-## v0.3.0 - (2019-03-08)
+## v1.0.0 - 2019-08-05
 
 ###Added
 
-* {GFW-Tasks/issues/968}(https://github.com/GlobalFishingWatch/GFW-Tasks/issues/968) Make pipe-tools master up to date
+* [GFW-Tasks/issues/1100](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100): Adds
+  Update of airflow from 1.10.1 to 1.10.2
+  CLOUD_SDK_VERSION was updated from 198.0.0 to 248.0.0
+  The `tzlocal` library has deployed a new version on 23rd of July, the
+  version `2.0.0` (https://pypi.org/project/tzlocal/2.0.0/#history). This lib
+  brokes the compilation. Apache Airflow requires the `tzlocal` and
+  `pendulum` libraries to be installed. In the `setup.py` file, the section
+  `install_requires`, appears the dependencies and the lib `tzlocal>=1.4` and
+  `pendulum==1.4.4`
+  (https://github.com/apache/airflow/blob/1.10.2/setup.py#L337). The
+  `pendulum` lib brokes with lib `tzlocal==2.0.0`, so right now I pinned to
+  the previous version, the `1.5.1`.
+  Removing the `pipe-tools` dependency in pipe-airflow. This library will be
+  used for projects that will run inside airflow.
+
+## v0.3.0 - 2019-03-08
+
+###Added
+
+* [GFW-Tasks/issues/968](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/968): Changes making pipe-tools master up to date
   * Replacing the [pipe-tools](https://github.com/GlobalFishingWatch/pipe-tools) lib with the [airflow-gfw](https://github.com/GlobalFishingWatch/airflow-gfw) lib
 
-## v0.2.9 - (2019-03-07)
+## v0.2.9 - 2019-03-07
 
 ###Added
-* [GFW-Tasks/issues/912](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/912)
-  * The number of task instances allowed to run concurrently was reduced to 3. Using 16 instances restarts the web pod recursively.
-  * Adds kubernetes section in `airflow.cfg`
-  * Adds authentication step before installing DAGs to let pull images from grc.io repo.
+
+* [GFW-Tasks/issues/912](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/912): Adds
+  The number of task instances allowed to run concurrently was reduced to 3.
+  Using 16 instances restarts the web pod recursively.
+  Adds kubernetes section in `airflow.cfg`
+  Adds authentication step before installing DAGs to let pull images from grc.io repo.
 
 
 ### Added
-  * [#884](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/884):
-    * Migrates Airflow version to 1.10.1 on pipe-tools.
-    * Uses `postgres` instead of `mysql`, because the property specified here (https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#mysql-setting-required) could not be changed in CloudSQL.
-    * Update the pipe-tools version to 1.0.0.
+
+* [#884](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/884): Adds
+  Migrates Airflow version to 1.10.1 on pipe-tools.
+  Uses `postgres` instead of `mysql`, because the property specified here
+  (https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#mysql-setting-required)
+  could not be changed in CloudSQL.
+  Update the pipe-tools version to 1.0.0.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,22 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+###Added
+
+* {GFW-Tasks/issues/1100}(https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100): Adds
+  * Update of airflow from 1.10.1 to 1.10.2
+  * CLOUD_SDK_VERSION was updated from 198.0.0 to 248.0.0
+  * The `tzlocal` library has deployed a new version on 23rd of July, the
+   version `2.0.0` (https://pypi.org/project/tzlocal/2.0.0/#history). This lib
+   brokes the compilation. Apache Airflow requires the `tzlocal` and
+   `pendulum` libraries to be installed. In the `setup.py` file, the section
+   `install_requires`, appears the dependencies and the lib `tzlocal>=1.4` and
+   `pendulum==1.4.4`
+   (https://github.com/apache/airflow/blob/1.10.2/setup.py#L337). The
+   `pendulum` lib brokes with lib `tzlocal==2.0.0`, so right now I pinned to
+   the previous version, the `1.5.1`.
+  * Removing the `pipe-tools` dependency in pipe-airflow. This library will be used for projects that will run inside airflow.
+
 ## v0.3.0 - (2019-03-08)
 
 ###Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d1100-4
+ENV AIRFLOW_GFW_VERSION d1100-6
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
@@ -78,6 +78,7 @@ RUN set -ex \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install celery[redis] \
+    && pip install tzlocal==1.5.1 \
     && pip install apache-airflow[postgres,crypto,celery,jdbc]==$AIRFLOW_VERSION \
     && pip install psycopg2 \
     && apt-get remove --purge -yqq $buildDeps libpq-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 
 # Download and install google cloud. See the dockerfile at
 # https://hub.docker.com/r/google/cloud-sdk/~/dockerfile/
-ENV CLOUD_SDK_VERSION 255.0.0
+ENV CLOUD_SDK_VERSION 248.0.0
 RUN apt-get -qqy update && apt-get install -qqy \
         gnupg \
         curl \
@@ -94,6 +94,7 @@ RUN set -ex \
 
 # Setup pipeline debugging tools
 RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/${PIPE_TOOLS_VERSION}
+RUN pip install google-auth==1.6.3
 RUN pip install https://github.com/GlobalFishingWatch/airflow-gfw/archive/${AIRFLOW_GFW_VERSION}.tar.gz
 
 # Setup airflow home directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d1100-6
+ENV AIRFLOW_GFW_VERSION d1100-7
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 # Pipe-tools
 ENV PIPE_TOOLS_VERSION v1.0.0
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION v0.0.1-dev3
+ENV AIRFLOW_GFW_VERSION d1100-1
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d1100-8
+ENV AIRFLOW_GFW_VERSION d1100-9
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d1100-9
+ENV AIRFLOW_GFW_VERSION d1100-10
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 # Pipe-tools
 ENV PIPE_TOOLS_VERSION v1.0.0
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d1100-4
+ENV AIRFLOW_GFW_VERSION d1100-5
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
@@ -94,7 +94,6 @@ RUN set -ex \
 
 # Setup pipeline debugging tools
 RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/${PIPE_TOOLS_VERSION}
-RUN pip install google-auth==1.6.3
 RUN pip install https://github.com/GlobalFishingWatch/airflow-gfw/archive/${AIRFLOW_GFW_VERSION}.tar.gz
 
 # Setup airflow home directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN set -ex \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install celery[redis] \
-    && pip install tzlocal==1.5.1 \
+    && pip install tzlocal==1.5.1 \ #TODO remove this line when we upgrade to airflow 1.10.4, version 2.0.0 of tzlocal produce an error in the SSL handshage for httplib
     && pip install apache-airflow[postgres,crypto,celery,jdbc]==$AIRFLOW_VERSION \
     && pip install psycopg2 \
     && apt-get remove --purge -yqq $buildDeps libpq-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 # Pipe-tools
 ENV PIPE_TOOLS_VERSION v1.0.0
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d1100-1
+ENV AIRFLOW_GFW_VERSION d1100-4
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,8 @@ ENV AIRFLOW_VERSION 1.10.2
 ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
-# Pipe-tools
-ENV PIPE_TOOLS_VERSION v1.0.0
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d1100-5
+ENV AIRFLOW_GFW_VERSION d1100-4
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
@@ -93,7 +91,6 @@ RUN set -ex \
         /usr/share/doc-base
 
 # Setup pipeline debugging tools
-RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/${PIPE_TOOLS_VERSION}
 RUN pip install https://github.com/GlobalFishingWatch/airflow-gfw/archive/${AIRFLOW_GFW_VERSION}.tar.gz
 
 # Setup airflow home directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d1100-10
+ENV AIRFLOW_GFW_VERSION d1100-11
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,8 @@ RUN set -ex \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install celery[redis] \
-    && pip install tzlocal==1.5.1 \ #TODO remove this line when we upgrade to airflow 1.10.4, version 2.0.0 of tzlocal produce an error in the SSL handshage for httplib
+    #TODO remove this line when we upgrade to airflow 1.10.4, version 2.0.0 of tzlocal produce an error in the SSL handshage for httplib
+    && pip install tzlocal==1.5.1 \
     && pip install apache-airflow[postgres,crypto,celery,jdbc]==$AIRFLOW_VERSION \
     && pip install psycopg2 \
     && apt-get remove --purge -yqq $buildDeps libpq-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d1100-7
+ENV AIRFLOW_GFW_VERSION d1100-8
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d1100-11
+ENV AIRFLOW_GFW_VERSION v0.0.2
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get -qqy update && apt-get install -qqy \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update && \
     apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 && \
+    pip install google-auth==1.6.3 && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 
 # Download and install google cloud. See the dockerfile at
 # https://hub.docker.com/r/google/cloud-sdk/~/dockerfile/
-ENV CLOUD_SDK_VERSION 248.0.0
+ENV CLOUD_SDK_VERSION 255.0.0
 RUN apt-get -qqy update && apt-get install -qqy \
         gnupg \
         curl \
@@ -39,7 +39,6 @@ RUN apt-get -qqy update && apt-get install -qqy \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update && \
     apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 && \
-    pip install google-auth==1.6.3 && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 
 # Download and install google cloud. See the dockerfile at
 # https://hub.docker.com/r/google/cloud-sdk/~/dockerfile/
-ENV CLOUD_SDK_VERSION 198.0.0
+ENV CLOUD_SDK_VERSION 248.0.0
 RUN apt-get -qqy update && apt-get install -qqy \
         gnupg \
         curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow configuration
-ENV AIRFLOW_VERSION 1.10.1
+ENV AIRFLOW_VERSION 1.10.2
 ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 


### PR DESCRIPTION

* Update of airflow from `1.10.1` to `1.10.2`
Upgrade, same version in cluster and same versions in client.

* AIRFLOW_GFW_VERSION was updated from `v0.0.1-dev3` to `d1100-6`
Because I am testing a new wrapper, the FlexibleOperator.

* CLOUD_SDK_VERSION was updated from `198.0.0` to `248.0.0`
This is the version we are using right now, and let us use new components.

* `pip install tzlocal==1.5.1`
The `tzlocal` library has deployed a new version on 23rd of July, the version `2.0.0` (https://pypi.org/project/tzlocal/2.0.0/#history).
Apache Airflow requires the `tzlocal` and `pendulum` libraries to be installed. In the `setup.py` file, the section `install_requires`, appears the dependencies and the lib `tzlocal>=1.4` and `pendulum==1.4.4` (https://github.com/apache/airflow/blob/1.10.2/setup.py#L337).
The `pendulum` lib brokes with lib `tzlocal==2.0.0`, so right now I pinned to the previous version, the `1.5.1`.

* RUN pip install https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/${PIPE_TOOLS_VERSION}
Removing the `pipe-tools` dependency in pipe-airflow. This library will be used for projects that will run inside airflow.

Related with> https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100