### PR TITLE
Features/1160 notify on failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
-## v1.0.2 - 2019-11-14
+## v1.0.2 - 2019-11-21
 
 ### Changed
 
@@ -16,6 +16,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
     the `Apache Airflow` version from `1.10.2` to `1.10.5`.
     And the `Airflow-GFW` version from `v0.0.2` to `v0.0.3`.
     And the `Cloud-SDK` version from `248.0.0` to `255.0.0`.
+    Needs to set the variable `SLACK_WEBHOOK_TOKEN` to send notification when a task fails.
 
 ## v1.0.1 - 2019-08-13
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,18 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v1.0.2 - 2019-11-14
+
+### Changed
+
+* [GFW-Tasks/issues/1160](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1160): Changed
+    the `Apache Airflow` version from `1.10.2` to `1.10.5`.
+    And the `Airflow-GFW` version from `v0.0.2` to `v0.0.3`.
+    And the `Cloud-SDK` version from `248.0.0` to `255.0.0`.
+
 ## v1.0.1 - 2019-08-13
 
-###Added
+### Added
 
 * [GFW-Tasks/issues/1112](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1112): Adds
     a validator on the Docker Daemon connection if it is open. If not try at least 10 times.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,19 +7,19 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow configuration
-ENV AIRFLOW_VERSION 1.10.2
+ENV AIRFLOW_VERSION 1.10.5
 ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION v0.0.2
+ENV AIRFLOW_GFW_VERSION d1160-1
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 
 # Download and install google cloud. See the dockerfile at
 # https://hub.docker.com/r/google/cloud-sdk/~/dockerfile/
-ENV CLOUD_SDK_VERSION 248.0.0
+ENV CLOUD_SDK_VERSION 255.0.0
 RUN apt-get -qqy update && apt-get install -qqy \
         gnupg \
         curl \
@@ -78,8 +78,6 @@ RUN set -ex \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install celery[redis] \
-    #TODO remove this line when we upgrade to airflow 1.10.4, version 2.0.0 of tzlocal produce an error in the SSL handshage for httplib
-    && pip install tzlocal==1.5.1 \
     && pip install apache-airflow[postgres,crypto,celery,jdbc]==$AIRFLOW_VERSION \
     && pip install psycopg2 \
     && apt-get remove --purge -yqq $buildDeps libpq-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN set -ex \
         nano \
     && useradd -ms /bin/bash -u 1001 -d ${AIRFLOW_HOME} airflow \
     && python -m pip install -U pip setuptools wheel \
+    && pip install marshmallow-sqlalchemy==0.17.2 \
     && pip install Cython \
     && pip install cryptography \
     && pip install pytz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d1160-1
+ENV AIRFLOW_GFW_VERSION d1160-6
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -162,9 +162,9 @@ dags_volume_subpath=${K8_DAGS_VOLUME_SUBPATH}
 default_hive_mapred_queue=
 # If True (default), worker pods will be deleted upon termination
 delete_worker_pods=True
-elasticsearch_end_of_log_mark=
-elasticsearch_host=
-elasticsearch_log_id_template=
+end_of_log_mark=
+host=
+log_id_template=
 # GCP Service Account Keys to be provided to tasks run on Kubernetes Executors
 # Should be supplied in the format: key-name-1:key-path-1,key-name-2:key-path-2
 gcp_service_account_keys=
@@ -214,9 +214,9 @@ tls_key=
 tls_ca=
 
 [elasticsearch]
-elasticsearch_end_of_log_mark=
-elasticsearch_host=
-elasticsearch_log_id_template=
+end_of_log_mark=
+host=
+log_id_template=
 
 # [mesos]
 # authenticate=

--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -162,9 +162,9 @@ dags_volume_subpath=${K8_DAGS_VOLUME_SUBPATH}
 default_hive_mapred_queue=
 # If True (default), worker pods will be deleted upon termination
 delete_worker_pods=True
-end_of_log_mark=
-host=
-log_id_template=
+elasticsearch_end_of_log_mark=
+elasticsearch_host=
+elasticsearch_log_id_template=
 # GCP Service Account Keys to be provided to tasks run on Kubernetes Executors
 # Should be supplied in the format: key-name-1:key-path-1,key-name-2:key-path-2
 gcp_service_account_keys=

--- a/scripts/initialize
+++ b/scripts/initialize
@@ -39,3 +39,9 @@ airflow connections --add   \
   --conn_id=google_cloud_default \
   --conn_type=google_cloud_platform  \
   --conn_extra={\"extra__google_cloud_platform__project\":\"${PROJECT_ID}\"}
+
+airflow connections --add   \
+  --conn_id=slack_on_failure \
+  --conn_type=http \
+  --conn_host=https://hooks.slack.com/services \
+  --conn_password=${SLACK_WEBHOOK_TOKEN}


### PR DESCRIPTION
Related with> https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1160

* Changed the `Apache Airflow` version from `1.10.2` to `1.10.5`.
* Changes the `Airflow-GFW` version from `v0.0.2` to `v0.0.3`. --> *PENDING*
* Changes the `Cloud-SDK` version from `248.0.0` to `255.0.0`.
* Needs to set the variable `SLACK_WEBHOOK_TOKEN` to send notification when a task fails.



Pending to:
* Configure the `Slack` `Channel` in the webhook.
* change the version for `AIRFLOW_GFW_VERSION`.
Approve this PR first: https://github.com/GlobalFishingWatch/airflow-gfw/pull/6
