### PR TITLE
Change the image of Airflow from default 2.7 to 3.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v1.0.7 - 2020-03-11
+
+### Changed
+
+* [GlobalFishingWatch/gfw-eng-tasks#3](https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/3): Changed
+    to Python3.7 and airflow-gfw:v1.0.0
+
 ## v1.0.6 - 2020-01-22
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d23-1
+ENV AIRFLOW_GFW_VERSION d23-3
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION v0.0.7
+ENV AIRFLOW_GFW_VERSION d23-1
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION d23-3
+ENV AIRFLOW_GFW_VERSION v1.0.0
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN set -ex \
         /usr/share/doc-base
 
 # Setup pipeline debugging tools
-RUN pip3 install https://github.com/GlobalFishingWatch/airflow-gfw/archive/${AIRFLOW_GFW_VERSION}.tar.gz
+RUN pip install https://github.com/GlobalFishingWatch/airflow-gfw/archive/${AIRFLOW_GFW_VERSION}.tar.gz
 
 # Setup airflow home directory
 WORKDIR ${AIRFLOW_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow configuration
-ENV AIRFLOW_VERSION 1.10.7
+ENV AIRFLOW_VERSION 1.10.5
 ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 
 # Download and install google cloud. See the dockerfile at
 # https://hub.docker.com/r/google/cloud-sdk/~/dockerfile/
-ENV CLOUD_SDK_VERSION 255.0.0
+ENV CLOUD_SDK_VERSION 268.0.0
 RUN apt-get -qqy update && apt-get install -qqy \
         gnupg \
         curl \
@@ -31,7 +31,7 @@ RUN apt-get -qqy update && apt-get install -qqy \
         openssh-client \
         git \
     && easy_install -U pip && \
-    pip3 install -U crcmod   && \
+    pip install -U crcmod   && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
@@ -71,16 +71,16 @@ RUN set -ex \
         nano \
     && useradd -ms /bin/bash -u 1001 -d ${AIRFLOW_HOME} airflow \
     && python -m pip install -U pip setuptools wheel \
-    && pip3 install marshmallow-sqlalchemy==0.17.2 \
-    && pip3 install Cython \
-    && pip3 install cryptography \
-    && pip3 install pytz \
-    && pip3 install pyOpenSSL \
-    && pip3 install ndg-httpsclient \
-    && pip3 install pyasn1 \
-    && pip3 install celery[redis] \
-    && pip3 install apache-airflow[postgres,crypto,celery,jdbc]==$AIRFLOW_VERSION \
-    && pip3 install psycopg2 \
+    && pip install marshmallow-sqlalchemy==0.17.2 \
+    && pip install Cython \
+    && pip install cryptography \
+    && pip install pytz \
+    && pip install pyOpenSSL \
+    && pip install ndg-httpsclient \
+    && pip install pyasn1 \
+    && pip install celery[redis] \
+    && pip install apache-airflow[postgres,crypto,celery,jdbc]==$AIRFLOW_VERSION \
+    && pip install psycopg2 \
     && apt-get remove --purge -yqq $buildDeps libpq-dev \
     && apt-get clean \
     && rm -rf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:17.12.0-ce as static-docker-source
 
-FROM python:3.8.1-slim-buster
+FROM python:3.7.6-slim-buster
 
 # Never prompts the user for choices on installation/configuration of packages
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM docker:17.12.0-ce as static-docker-source
 
-FROM python:2.7-slim
+FROM python:3.8.1-slim-buster
 
 # Never prompts the user for choices on installation/configuration of packages
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow configuration
-ENV AIRFLOW_VERSION 1.10.5
+ENV AIRFLOW_VERSION 1.10.7
 ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
@@ -31,7 +31,7 @@ RUN apt-get -qqy update && apt-get install -qqy \
         openssh-client \
         git \
     && easy_install -U pip && \
-    pip install -U crcmod   && \
+    pip3 install -U crcmod   && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
@@ -71,16 +71,16 @@ RUN set -ex \
         nano \
     && useradd -ms /bin/bash -u 1001 -d ${AIRFLOW_HOME} airflow \
     && python -m pip install -U pip setuptools wheel \
-    && pip install marshmallow-sqlalchemy==0.17.2 \
-    && pip install Cython \
-    && pip install cryptography \
-    && pip install pytz \
-    && pip install pyOpenSSL \
-    && pip install ndg-httpsclient \
-    && pip install pyasn1 \
-    && pip install celery[redis] \
-    && pip install apache-airflow[postgres,crypto,celery,jdbc]==$AIRFLOW_VERSION \
-    && pip install psycopg2 \
+    && pip3 install marshmallow-sqlalchemy==0.17.2 \
+    && pip3 install Cython \
+    && pip3 install cryptography \
+    && pip3 install pytz \
+    && pip3 install pyOpenSSL \
+    && pip3 install ndg-httpsclient \
+    && pip3 install pyasn1 \
+    && pip3 install celery[redis] \
+    && pip3 install apache-airflow[postgres,crypto,celery,jdbc]==$AIRFLOW_VERSION \
+    && pip3 install psycopg2 \
     && apt-get remove --purge -yqq $buildDeps libpq-dev \
     && apt-get clean \
     && rm -rf \
@@ -92,7 +92,7 @@ RUN set -ex \
         /usr/share/doc-base
 
 # Setup pipeline debugging tools
-RUN pip install https://github.com/GlobalFishingWatch/airflow-gfw/archive/${AIRFLOW_GFW_VERSION}.tar.gz
+RUN pip3 install https://github.com/GlobalFishingWatch/airflow-gfw/archive/${AIRFLOW_GFW_VERSION}.tar.gz
 
 # Setup airflow home directory
 WORKDIR ${AIRFLOW_HOME}

--- a/utils/log_wrapper.py
+++ b/utils/log_wrapper.py
@@ -29,7 +29,7 @@ def get_logger(options):
 
 def log_line(line, logger):
     # TODO: Should just use another handler in the logger to sent to stdout
-    print line
+    print(line)
     logger.info(line)
 
 


### PR DESCRIPTION
Closes Globalfishingwatch/gfw-eng-tasks#3 

Moves from 2.7-slim that uses buster to 3.7 that uses buster and changed all pip install so it uses all python 3 libraries. 

I've not used 3.8 since there was a problem with psycog. We should move to 3.8 and airflow 1.10.7 in the future. 

We can squash the commits since they included other changes that were reverted. 