### PR TITLE
Does not reattach to pod

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,16 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ## [Unreleased]
 
 
+## v1.4.0 - 2021-05-17
+
+### Changed
+
+* [PIPELINE-393](https://globalfishingwatch.atlassian.net/browse/PIPELINE-393): Changes
+  do NOT reattach to pod after restart kubernetes cluster. This will let
+  create a new pod to start processing the tasks from scratch and avoid
+  having last issues on keeping requesting the pod and get confusion when
+  it's declared as success state.
+
 ## v1.3.0 - 2021-04-28
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 #Airflow-gfw
-ENV AIRFLOW_GFW_VERSION v1.3.0
+ENV AIRFLOW_GFW_VERSION v1.4.0
 
 # Use the docker binary from the other source
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 
 # Download and install google cloud. See the dockerfile at
 # https://hub.docker.com/r/google/cloud-sdk/~/dockerfile/
-ENV CLOUD_SDK_VERSION 338.0.0
+ENV CLOUD_SDK_VERSION 340.0.0
 RUN apt-get -qqy update && apt-get install -qqy \
         gnupg \
         curl \


### PR DESCRIPTION
    do NOT reattach to pod after restart kubernetes cluster. This will let
    create a new pod to start processing the tasks from scratch and avoid
    having last issues on keeping requesting the pod and get confusion when
    it's declared as success state.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-393